### PR TITLE
chore: 🤖 .coderabbit.yaml を本格運用向けに拡充

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,14 +1,14 @@
 # CodeRabbit configuration
 # https://docs.coderabbit.ai/reference/configuration
 
-language: 'ja-JP'
+language: "ja-JP"
 early_access: false
 enable_free_tier: true
 
 reviews:
   # Docker Hub のタグ列挙 CLI を同梱した OSS Docker イメージを配布しているリポジトリのため、利用者環境への影響を取りこぼしたくない。
   # "assertive" で検出感度を高めに保ち、ノイズが過剰になった場合は "chill" に戻すことも検討する。
-  profile: 'assertive'
+  profile: "assertive"
 
   # PR 全体に対する指針。path_instructions に "**/*" を入れるとファイル毎に
   # 繰り返し適用されてノイズが増えるため、広範な指示は instructions に集約する。
@@ -37,20 +37,20 @@ reviews:
       - main
 
   path_instructions:
-    - path: 'Dockerfile*'
+    - path: "Dockerfile*"
       instructions: |
         Dockerfile としてレビューしてください:
         - ベースイメージのバージョンが固定 (タグ pin / digest pin) されているか。
         - 不要なパッケージ／キャッシュが残っていないか (イメージサイズと攻撃面の最小化)。
         - 機密情報 (鍵 / トークン) が ARG / ENV / COPY 経由で露出していないか。
         - root のまま実行していないか、非 root ユーザ切替を検討すべきか。
-    - path: '**/*.sh'
+    - path: "**/*.sh"
       instructions: |
         シェルスクリプトとしてレビューしてください:
         - `set -euo pipefail` 相当のエラー伝播設定が入っているか。
         - 変数展開のクォート漏れ・単語分割によるバグや任意コード実行の余地が無いか。
         - 外部入力をそのまま `eval` / `sh -c` へ流していないか。
-    - path: '.github/workflows/**'
+    - path: ".github/workflows/**"
       instructions: |
         GitHub Actions ワークフローとしてレビューしてください:
         - シークレットの露出 (echo / set-output 経由のリーク) が無いか。
@@ -59,24 +59,24 @@ reviews:
 
   # 生成物 / 依存物 / ロックファイルなどはレビュー対象から除外する。
   path_filters:
-    - '!**/dist/**'
-    - '!**/build/**'
-    - '!**/coverage/**'
-    - '!**/node_modules/**'
-    - '!**/.wrangler/**'
-    - '!**/.turbo/**'
-    - '!**/.next/**'
-    - '!infra/cdktf.out/**'
-    - '!infra/.gen/**'
-    - '!**/bun.lock'
-    - '!**/package-lock.json'
-    - '!**/yarn.lock'
-    - '!**/pnpm-lock.yaml'
-    - '!**/*.min.js'
-    - '!**/*.min.css'
-    - '!**/*.map'
-    - '!**/*.snap'
-    - '!**/*.tsbuildinfo'
+    - "**/dist/**"
+    - "**/build/**"
+    - "**/coverage/**"
+    - "**/node_modules/**"
+    - "**/.wrangler/**"
+    - "**/.turbo/**"
+    - "**/.next/**"
+    - "infra/cdktf.out/**"
+    - "infra/.gen/**"
+    - "**/bun.lock"
+    - "**/package-lock.json"
+    - "**/yarn.lock"
+    - "**/pnpm-lock.yaml"
+    - "**/*.min.js"
+    - "**/*.min.css"
+    - "**/*.map"
+    - "**/*.snap"
+    - "**/*.tsbuildinfo"
 
   abort_on_close: true
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,87 @@
-language: "ja-JP"
+# CodeRabbit configuration
+# https://docs.coderabbit.ai/reference/configuration
+
+language: 'ja-JP'
+early_access: false
+enable_free_tier: true
+
 reviews:
-  tone_instruction: "丁寧な日本語でレビューしてください。"
+  # Docker Hub のタグ列挙 CLI を同梱した OSS Docker イメージを配布しているリポジトリのため、利用者環境への影響を取りこぼしたくない。
+  # "assertive" で検出感度を高めに保ち、ノイズが過剰になった場合は "chill" に戻すことも検討する。
+  profile: 'assertive'
+
+  # PR 全体に対する指針。path_instructions に "**/*" を入れるとファイル毎に
+  # 繰り返し適用されてノイズが増えるため、広範な指示は instructions に集約する。
+  instructions: |
+    変更がプロジェクト全体に与える影響や、アーキテクチャの観点など、広いスコープからコードレビューを行ってください。必ず日本語でコメントしてください。
+    OSS として配布される Docker イメージ／CLI ツールのリポジトリであることを考慮し、以下の観点を強調し、重要視して必ずレビューに盛り込んでください:
+    - 認証情報、API キー、トークン、内部 URL などの秘密情報がコード・ログ・イメージ層に混入していないこと。
+    - 任意コード実行・コマンドインジェクション・パストラバーサルなど、利用者環境を危険にさらす脆弱性が無いこと。
+    - 入力検証（引数 / 標準入力 / 環境変数）が抜けていないこと。
+
+  # CodeRabbit を bot reviewer として動作させる。問題なしと判断した PR に対して
+  # Approve ステータスを返す。個人運営での self-merge 運用 (PR 作成者は自分の
+  # PR を承認できない GitHub 仕様) を補助する目的で有効化。Approve は最終判断
+  # ではなく補助。
+  request_changes_workflow: true
+
+  high_level_summary: true
   poem: false
+  review_status: true
+  collapse_walkthrough: true
+
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+
+  path_instructions:
+    - path: 'Dockerfile*'
+      instructions: |
+        Dockerfile としてレビューしてください:
+        - ベースイメージのバージョンが固定 (タグ pin / digest pin) されているか。
+        - 不要なパッケージ／キャッシュが残っていないか (イメージサイズと攻撃面の最小化)。
+        - 機密情報 (鍵 / トークン) が ARG / ENV / COPY 経由で露出していないか。
+        - root のまま実行していないか、非 root ユーザ切替を検討すべきか。
+    - path: '**/*.sh'
+      instructions: |
+        シェルスクリプトとしてレビューしてください:
+        - `set -euo pipefail` 相当のエラー伝播設定が入っているか。
+        - 変数展開のクォート漏れ・単語分割によるバグや任意コード実行の余地が無いか。
+        - 外部入力をそのまま `eval` / `sh -c` へ流していないか。
+    - path: '.github/workflows/**'
+      instructions: |
+        GitHub Actions ワークフローとしてレビューしてください:
+        - シークレットの露出 (echo / set-output 経由のリーク) が無いか。
+        - 外部 action は SHA pin されているか。
+        - permissions: が最小権限になっているか。
+
+  # 生成物 / 依存物 / ロックファイルなどはレビュー対象から除外する。
+  path_filters:
+    - '!**/dist/**'
+    - '!**/build/**'
+    - '!**/coverage/**'
+    - '!**/node_modules/**'
+    - '!**/.wrangler/**'
+    - '!**/.turbo/**'
+    - '!**/.next/**'
+    - '!infra/cdktf.out/**'
+    - '!infra/.gen/**'
+    - '!**/bun.lock'
+    - '!**/package-lock.json'
+    - '!**/yarn.lock'
+    - '!**/pnpm-lock.yaml'
+    - '!**/*.min.js'
+    - '!**/*.min.css'
+    - '!**/*.map'
+    - '!**/*.snap'
+    - '!**/*.tsbuildinfo'
+
+  abort_on_close: true
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  opt_out: false


### PR DESCRIPTION
## Summary

- CodeRabbit のレビュー指針 (`instructions`) を本リポジトリの性質に合わせて拡充
- `request_changes_workflow: true` を有効化し、問題なしと判断された PR に対する bot Approve を有効化（self-merge 運用の補助）
- `profile: 'assertive'` で検出感度を高めに固定
- `path_instructions` をリポジトリのスタックに合わせて整理（Dockerfile / Shell / Web / その他言語ごとの観点）
- `path_filters` で生成物・ロックファイル等のノイズを除外
- monopo / hyakuninissyu / toique と同じ運用ポリシーに揃え、個人運営リポジトリ間の設定差異を解消

## Test plan

- [ ] CodeRabbit が本 PR 自体に対して新ポリシーで自動レビューを行うこと
- [ ] 問題なしと判断された場合に CodeRabbit が Approve コメントを付与すること