### PR TITLE
chore(coderabbit): 🐇 planning / issue_enrichment / web_search を有効化

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,14 +6,6 @@ early_access: false
 enable_free_tier: true
 
 reviews:
-  planning:
-    enabled: true
-    auto_planning:
-      enabled: true
-      labels:
-        - feature
-        - enhancement
-        - bug
   # Docker Hub のタグ列挙 CLI を同梱した OSS Docker イメージを配布しているリポジトリのため、利用者環境への影響を取りこぼしたくない。
   # "assertive" で検出感度を高めに保ち、ノイズが過剰になった場合は "chill" に戻すことも検討する。
   profile: "assertive"
@@ -92,10 +84,20 @@ chat:
   auto_reply: true
 
 knowledge_base:
-  web_search:
-    enabled: true
   opt_out: false
 
 issue_enrichment:
   auto_enrich:
     enabled: true
+
+web_search:
+  enabled: true
+
+planning:
+  enabled: true
+  auto_planning:
+    enabled: true
+    labels:
+      - feature
+      - enhancement
+      - bug

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,6 +6,14 @@ early_access: false
 enable_free_tier: true
 
 reviews:
+  planning:
+    enabled: true
+    auto_planning:
+      enabled: true
+      labels:
+        - feature
+        - enhancement
+        - bug
   # Docker Hub のタグ列挙 CLI を同梱した OSS Docker イメージを配布しているリポジトリのため、利用者環境への影響を取りこぼしたくない。
   # "assertive" で検出感度を高めに保ち、ノイズが過剰になった場合は "chill" に戻すことも検討する。
   profile: "assertive"
@@ -84,4 +92,10 @@ chat:
   auto_reply: true
 
 knowledge_base:
+  web_search:
+    enabled: true
   opt_out: false
+
+issue_enrichment:
+  auto_enrich:
+    enabled: true


### PR DESCRIPTION
## 概要

hyakuninissyu リポジトリの `.coderabbit.yaml` で導入済みの設定を、本リポジトリの CodeRabbit 設定にも展開します。既に設定済みの項目は変更しません（冪等）。

## 変更内容

- `reviews.planning` を有効化（`auto_planning` を `feature` / `enhancement` / `bug` ラベルでトリガー）。PR 全体の意図を踏まえた計画ベースのレビューを行わせる。
- `issue_enrichment.auto_enrich` を有効化。作成された Issue を自動で情報拡充する。
- `knowledge_base.web_search` を有効化。Knowledge Base 照合時に Web 検索も併用する。

すべて CodeRabbit の無料枠で利用可能な機能です。
