### PR TITLE
ci: 🔧 CI/CDワークフローを全リポジトリ共通の正規版へ統一

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -2,15 +2,15 @@ name: actionlint
 
 on:
   push:
-    branches: [main]
+    branches: [main, master]
     paths:
-      - '.github/workflows/**'
-      - '.github/actionlint*'
+      - ".github/workflows/**"
+      - ".github/actionlint*"
   pull_request:
-    branches: [main]
+    branches: [main, master]
     paths:
-      - '.github/workflows/**'
-      - '.github/actionlint*'
+      - ".github/workflows/**"
+      - ".github/actionlint*"
 
 concurrency:
   group: actionlint-${{ github.ref }}
@@ -52,41 +52,43 @@ jobs:
         run: |
           "${{ steps.actionlint.outputs.executable }}" -color
 
-      - name: Reject mutable branch references in `uses:`
-        # 外部 Action を `@main` 等のブランチ追跡で参照すると、上流のリポジトリ
-        # リネーム時に `startup_failure` を起こす（cf. PR #137 で発生）ほか、
-        # 不意な破壊的変更を取り込むリスクがある。可変ブランチ参照を禁止し、
-        # コミット SHA でのピン留めを CI で強制する。
-        # （タグ参照 `@v1` の検出は zizmor 等の専用ツールに任せ、ここでは
-        #  実害の大きいブランチ参照のみを最小コストで弾く方針）
+      - name: Reject non-SHA action references in `uses:`
+        # 外部 Action をブランチ・タグ参照すると、上流のリポジトリリネームや
+        # タグ付け替えで startup_failure や不意の破壊的変更・供給網攻撃を
+        # 取り込むリスクがある。コミット SHA (40桁) でのピン留めを CI で強制する。
         #
-        # grep のパターンには 2 つの工夫を入れている:
-        #  1. `u[s]es:` で `uses:` リテラルを文字クラスに分解 → 本ステップ自身
+        # grep のパターンには 3 つの工夫を入れている:
+        #  1. `u[s]es` で `uses` リテラルを文字クラスに分解 → 本ステップ自身
         #     が自分の検出パターンに hit するのを防ぐ（self-match 回避）。
         #  2. 行頭アンカー `^[[:space:]]*-?[[:space:]]*` で YAML キー位置に
         #     限定し、コメントや文字列内の偶発的な `uses:` を除外。加えて
         #     `--include='*.yml' --include='*.yaml'` で対象拡張子を絞る。
+        #  3. キー・値を囲むクオート（`"..."` / `'...'`）を任意でマッチさせる
+        #     → `uses: "owner/repo@main"` のようなクオート記法での
+        #     ガードバイパスを防ぐ（YAML 上いずれも有効な記法のため）。
         run: |
           set -euo pipefail
-          violations=$(grep -rEn \
+          refs=$(grep -rEn \
             --include='*.yml' --include='*.yaml' \
-            '^[[:space:]]*-?[[:space:]]*u[s]es:[[:space:]]+[^@[:space:]]+@(main|master|develop|trunk|HEAD)([[:space:]]|$)' \
+            -e "^[[:space:]]*-?[[:space:]]*[\"']?u[s]es[\"']?[[:space:]]*:[[:space:]]+[\"']?[^@[:space:]\"']+@[^[:space:]\"'#]+" \
             .github/workflows || true)
+          violations=$(printf '%s\n' "$refs" | grep -Ev "@[0-9a-fA-F]{40}([\"'[:space:]]|#|$)" | grep -v '^$' || true)
           if [ -n "$violations" ]; then
-            echo "::error::外部 Action 参照に可変ブランチが使われています。コミット SHA でピン留めしてください:"
+            echo "::error::外部 Action 参照がコミット SHA でピン留めされていません:"
             echo "$violations"
             echo ""
             echo "修正方法: \`uses: owner/repo@<40桁SHA> # v1.2.3\` の形式に書き換える。"
             exit 1
           fi
-          echo "✅ 全ての外部 Action 参照がブランチ追跡を回避できています。"
+          echo "✅ 全ての外部 Action 参照がコミット SHA でピン留めされています。"
 
       - name: Reject pull_request_target
         run: |
           set -euo pipefail
           violations=$(grep -rEn \
             --include='*.yml' --include='*.yaml' \
-            '^[[:space:]]*pull_request_targ[e]t:' \
+            -e "^[[:space:]]*[\"']?pull_request_targ[e]t[\"']?[[:space:]]*:" \
+            -e "^[[:space:]]*[\"']?on[\"']?[[:space:]]*:[[:space:]]*\[[^]]*pull_request_targ[e]t[^]]*\]" \
             .github/workflows || true)
           if [ -n "$violations" ]; then
             echo "::error::フォークPRからのシークレット漏洩リスクがあるため、pull_request_target の使用は禁止されています:"

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [main, master]
     paths:
-      - ".github/workflows/**"
-      - ".github/actionlint*"
+      - '.github/workflows/**'
+      - '.github/actionlint*'
   pull_request:
     branches: [main, master]
     paths:
-      - ".github/workflows/**"
-      - ".github/actionlint*"
+      - '.github/workflows/**'
+      - '.github/actionlint*'
 
 concurrency:
   group: actionlint-${{ github.ref }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -2,12 +2,12 @@ name: Gitleaks
 
 on:
   push:
-    branches: [main]
+    branches: [main, master]
   pull_request:
-    branches: [main]
+    branches: [main, master]
   schedule:
     # 毎週月曜 05:00 JST (= 日曜 20:00 UTC) に履歴全体を再スキャン
-    - cron: '0 20 * * 0'
+    - cron: "0 20 * * 0"
   workflow_dispatch:
 
 concurrency:
@@ -33,8 +33,11 @@ jobs:
         run: |
           set -euo pipefail
           GITLEAKS_VERSION=8.21.2
-          curl -fsSLO "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
-          tar -xzf "gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" gitleaks
+          TARBALL="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -fsSLO "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${TARBALL}"
+          curl -fsSLo checksums.txt "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_checksums.txt"
+          grep " ${TARBALL}$" checksums.txt | sha256sum -c -
+          tar -xzf "${TARBALL}" gitleaks
           sudo mv gitleaks /usr/local/bin/gitleaks
           gitleaks version
 
@@ -52,7 +55,7 @@ jobs:
 
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@78ed0c7291d93e40c51b085850dc669a4c3ab73b # v3
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: gitleaks.sarif
           category: gitleaks

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -7,7 +7,7 @@ on:
     branches: [main, master]
   schedule:
     # 毎週月曜 05:00 JST (= 日曜 20:00 UTC) に履歴全体を再スキャン
-    - cron: "0 20 * * 0"
+    - cron: '0 20 * * 0'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -2,14 +2,14 @@ name: hadolint
 
 on:
   push:
-    branches: [main]
+    branches: [main, master]
     paths:
       - "**/Dockerfile"
       - "**/Dockerfile.*"
       - ".hadolint.yaml"
       - ".github/workflows/hadolint.yml"
   pull_request:
-    branches: [main]
+    branches: [main, master]
     paths:
       - "**/Dockerfile"
       - "**/Dockerfile.*"

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -4,17 +4,17 @@ on:
   push:
     branches: [main, master]
     paths:
-      - "**/Dockerfile"
-      - "**/Dockerfile.*"
-      - ".hadolint.yaml"
-      - ".github/workflows/hadolint.yml"
+      - '**/Dockerfile'
+      - '**/Dockerfile.*'
+      - '.hadolint.yaml'
+      - '.github/workflows/hadolint.yml'
   pull_request:
     branches: [main, master]
     paths:
-      - "**/Dockerfile"
-      - "**/Dockerfile.*"
-      - ".hadolint.yaml"
-      - ".github/workflows/hadolint.yml"
+      - '**/Dockerfile'
+      - '**/Dockerfile.*'
+      - '.hadolint.yaml'
+      - '.github/workflows/hadolint.yml'
 
 concurrency:
   group: hadolint-${{ github.ref }}

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -2,17 +2,17 @@ name: markdownlint
 
 on:
   push:
-    branches: [main]
+    branches: [main, master]
     paths:
-      - '**/*.md'
-      - '.markdownlint-cli2.jsonc'
-      - '.github/workflows/markdownlint.yml'
+      - "**/*.md"
+      - ".markdownlint-cli2.jsonc"
+      - ".github/workflows/markdownlint.yml"
   pull_request:
-    branches: [main]
+    branches: [main, master]
     paths:
-      - '**/*.md'
-      - '.markdownlint-cli2.jsonc'
-      - '.github/workflows/markdownlint.yml'
+      - "**/*.md"
+      - ".markdownlint-cli2.jsonc"
+      - ".github/workflows/markdownlint.yml"
 
 concurrency:
   group: markdownlint-${{ github.ref }}
@@ -25,7 +25,7 @@ jobs:
   markdownlint:
     name: markdownlint-cli2
     runs-on: ubuntu-latest
-    # 既存ドキュメントの MD040/MD031 違反を片付けるまでは赤検知にしない。
+    # 既存ドキュメントの違反を片付けるまでは赤検知にしない。
     # 整備完了後に continue-on-error を外して赤検知に切り替える。
     continue-on-error: true
     steps:
@@ -38,5 +38,5 @@ jobs:
         # GitHub Actions runner が node24 を正式サポートするまで v22.0.0 で固定する。
         uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101 # v22.0.0
         with:
-          config: '.markdownlint-cli2.jsonc'
-          globs: '**/*.md'
+          config: ".markdownlint-cli2.jsonc"
+          globs: "**/*.md"

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -4,15 +4,15 @@ on:
   push:
     branches: [main, master]
     paths:
-      - "**/*.md"
-      - ".markdownlint-cli2.jsonc"
-      - ".github/workflows/markdownlint.yml"
+      - '**/*.md'
+      - '.markdownlint-cli2.jsonc'
+      - '.github/workflows/markdownlint.yml'
   pull_request:
     branches: [main, master]
     paths:
-      - "**/*.md"
-      - ".markdownlint-cli2.jsonc"
-      - ".github/workflows/markdownlint.yml"
+      - '**/*.md'
+      - '.markdownlint-cli2.jsonc'
+      - '.github/workflows/markdownlint.yml'
 
 concurrency:
   group: markdownlint-${{ github.ref }}
@@ -38,5 +38,5 @@ jobs:
         # GitHub Actions runner が node24 を正式サポートするまで v22.0.0 で固定する。
         uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101 # v22.0.0
         with:
-          config: ".markdownlint-cli2.jsonc"
-          globs: "**/*.md"
+          config: '.markdownlint-cli2.jsonc'
+          globs: '**/*.md'

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [main, master]
     paths:
-      - "**/*.sh"
-      - ".github/workflows/shellcheck.yml"
+      - '**/*.sh'
+      - '.github/workflows/shellcheck.yml'
   pull_request:
     branches: [main, master]
     paths:
-      - "**/*.sh"
-      - ".github/workflows/shellcheck.yml"
+      - '**/*.sh'
+      - '.github/workflows/shellcheck.yml'
 
 concurrency:
   group: shellcheck-${{ github.ref }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,45 @@
+name: shellcheck
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - "**/*.sh"
+      - ".github/workflows/shellcheck.yml"
+  pull_request:
+    branches: [main, master]
+    paths:
+      - "**/*.sh"
+      - ".github/workflows/shellcheck.yml"
+
+concurrency:
+  group: shellcheck-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: ShellCheck (shell script lint)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run shellcheck
+        run: |
+          set -euo pipefail
+          # ランナー同梱の shellcheck を使用する（バージョンはログで確認できるよう出力）。
+          shellcheck --version
+          # リポジトリ内の全シェルスクリプトを対象に lint する。
+          # サードパーティ由来の vendor / node_modules 配下は対象外。
+          mapfile -t scripts < <(git ls-files '*.sh' | grep -viE '(^|/)(vendor|node_modules)/' || true)
+          if [ "${#scripts[@]}" -eq 0 ]; then
+            echo "シェルスクリプトが見つかりませんでした。スキップします。"
+            exit 0
+          fi
+          printf 'lint 対象: %s\n' "${scripts[@]}"
+          shellcheck --severity=warning "${scripts[@]}"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -7,7 +7,7 @@ on:
     branches: [main, master]
   schedule:
     # 毎週月曜 04:00 JST (= 日曜 19:00 UTC) に再スキャンして新規 CVE を拾う
-    - cron: "0 19 * * 0"
+    - cron: '0 19 * * 0'
 
 concurrency:
   group: trivy-${{ github.ref }}
@@ -67,5 +67,5 @@ jobs:
         if: always()
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
-          sarif_file: "trivy-fs.sarif"
+          sarif_file: 'trivy-fs.sarif'
           category: trivy-fs

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -2,9 +2,9 @@ name: Trivy Scan
 
 on:
   push:
-    branches: [main]
+    branches: [main, master]
   pull_request:
-    branches: [main]
+    branches: [main, master]
   schedule:
     # 毎週月曜 04:00 JST (= 日曜 19:00 UTC) に再スキャンして新規 CVE を拾う
     - cron: "0 19 * * 0"
@@ -65,7 +65,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security
         if: always()
-        uses: github/codeql-action/upload-sarif@78ed0c7291d93e40c51b085850dc669a4c3ab73b # v3
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: "trivy-fs.sarif"
           category: trivy-fs

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,43 @@
+name: zizmor
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+concurrency:
+  group: zizmor-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+
+      - name: Run zizmor 🌈
+        run: uvx zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,9 +2,9 @@ name: zizmor
 
 on:
   push:
-    branches: ["**"]
+    branches: ['**']
   pull_request:
-    branches: ["**"]
+    branches: ['**']
 
 concurrency:
   group: zizmor-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,7 +44,7 @@ URL="https://registry.hub.docker.com/v2/repositories/${DOCKER_IMAGE}/tags/"
   echo "TAG SIZE UPDATED"
   echo "----- ----- -----"
   while [ "${URL}" != null ]; do
-    [[ -n "${REST_OF_OUTPUT_PAGE}" ]] && [[ ! "$((REST_OF_OUTPUT_PAGE--))" > 0 ]] && break
+    [[ -n "${REST_OF_OUTPUT_PAGE}" ]] && [[ ! "$((REST_OF_OUTPUT_PAGE--))" -gt 0 ]] && break
 
     RESPONSE="$(
       curl --keepalive-time 300 -4 --silent "${URL}" 2>/dev/null

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,7 +44,7 @@ URL="https://registry.hub.docker.com/v2/repositories/${DOCKER_IMAGE}/tags/"
   echo "TAG SIZE UPDATED"
   echo "----- ----- -----"
   while [ "${URL}" != null ]; do
-    [[ -n "${REST_OF_OUTPUT_PAGE}" ]] && [[ ! "$((REST_OF_OUTPUT_PAGE--))" -gt 0 ]] && break
+    [[ -n "${REST_OF_OUTPUT_PAGE}" ]] && (( REST_OF_OUTPUT_PAGE-- <= 0 )) && break
 
     RESPONSE="$(
       curl --keepalive-time 300 -4 --silent "${URL}" 2>/dev/null


### PR DESCRIPTION
## 概要

genzouw 配下の公開リポジトリ間でドリフトしていた共通CIワークフローを、単一の正規版(全リポジトリでバイト同一)へ統一します。全公開リポジトリへ同内容のPRを展開する共通化施策の一環です(パイロット: genzouw/gpg#7 で全チェックグリーンを確認済み)。

## 変更内容

| ワークフロー | 変更 | 内容 |
|---|---|---|
| actionlint.yml | 強化 | 全 `uses:` のコミットSHAピン留めをCIで強制(タグ参照も禁止)、`pull_request_target` 禁止、クオート記法によるガードバイパス対策 |
| gitleaks.yml | 強化 | チェックサム検証付きインストール、`--log-opts=--all` で全ブランチ履歴をスキャン、SARIF アップロードを codeql-action v4 へ更新 |
| markdownlint.yml | 統一 | トリガーを `[main, master]` へ汎用化(リポジトリ間の差分排除) |
| hadolint.yml | 統一 | 同上。Dockerfile が無ければ自動スキップ |
| trivy.yml | 統一 | 同上 + codeql-action v4 へ更新 |
| zizmor.yml | 新規 | GitHub Actions ワークフローのセキュリティ監査(SARIF を Security タブへ) |
| shellcheck.yml | 新規 | シェルスクリプト lint(vendor/node_modules 除外、severity=warning)。`.sh` が無ければ自動スキップ |

## このリポジトリ固有の変更

- `entrypoint.sh`: SC2071 (数値比較に文字列演算子 `>` を誤用、ページネーション打ち切り判定が正しく動かない実バグ) を `-gt` へ修正

## 共通化の方針

- トリガーブランチを `[main, master]` 併記にすることで、デフォルトブランチ名が異なるリポジトリ間でもファイルをバイト同一に保つ
- hadolint / shellcheck は対象ファイルが無ければ自動スキップするため、全リポジトリに同一セットを配布できる
- すべての外部 Action はコミットSHAでピン留めし、ダウンロードするバイナリはチェックサム検証を実施

## 検証

- `actionlint` ローカル実行: 0エラー
- 厳格化した SHA ピン留めチェック・pull_request_target チェックを本リポジトリの全ワークフローに対してローカルで事前実行し、違反 0 件を確認
- gitleaks 全履歴スキャン(pin版と同等ルール)およびshellcheck をローカルで事前実行し、グリーンを確認

https://claude.ai/code/session_01EZDkTJMVWFqUL3Q5DzkZ7d